### PR TITLE
Fix JPG Requests

### DIFF
--- a/src/api2.py
+++ b/src/api2.py
@@ -41,7 +41,7 @@ async def post(request):
 
 async def get(request):
     filename = request.match_info['filename']
-    if not re.match(r'^[A-Za-z0-9]{64}\.(pdf|png|pdf)$', filename):
+    if not re.match(r'^[A-Za-z0-9]{64}\.(jpg|png|pdf)$', filename):
         logs.info('{} not found'.format(filename))
         raise aiohttp.web.HTTPBadRequest
     path = './temp/' + filename.replace('.', '/a.')


### PR DESCRIPTION
Closes #4 
Requests to the get file endpoint for JPEG files would always fail since the regex incorrectly specified PDF twice, but not JPG.